### PR TITLE
Added naur discussion skill

### DIFF
--- a/aai_coding/theory.py
+++ b/aai_coding/theory.py
@@ -1,0 +1,23 @@
+r'''What "Theory" (capital T) means in this team's vocabulary: Peter Naur's programming-as-theory-building. Read when the user says the Theory of something, or asks to discuss, find, or capture a Theory.
+
+# The Theory
+
+"Theory" here is Naur's sense, from his 1985 paper Programming as Theory Building. A program is not its source code or its docs. It is the theory held in its builders' minds: their understanding of how the code maps onto the world, why it is the way it is, and how it can be sensibly extended.
+
+Consequences Naur draws:
+
+- The main consequence is that the Theory needs to be held in the developers' minds. To do so, it needs to be expressed in its most minimal representation. There is always time to get into details later, but when discussing the Theory conciseness is king. It does not mean to exclude important details, it does not mean we want to give the developer the illusion of control. It means we iterate until we find the Core that is true and we want to anchor into.
+- The theory cannot be fully written down. Documentation captures artifacts of the theory, not the theory itself, which is why "just read the docs" never fully onboards anyone.
+- Program death: a program whose theory-holders have all left is effectively dead, even if it still runs. Reviving it is closer to rebuilding than reading.
+- Modification quality depends on the theory, not the code. Someone with the theory makes changes that fit the program's nature; someone without it makes patches that gradually corrode the design.
+
+# Using it
+
+When jumping into a new codebase, figure out the Theory first, then understand the code through it: the driving facts or constraints, the derivation of the design from them, and the alternatives rejected and why.
+
+When reviewing a PR, ask what Theory the change assumes and whether that matches the Theory of the codebase. A patch can be locally correct and still theory-violating, and that class of problem is invisible to line-by-line review.
+
+When the user says "the Theory of X", this vocabulary is assumed; do not re-explain Naur. Discussing a Theory means talking it through in conversation. Do not turn it into a process, a checklist, or markdown files unless the user explicitly asks for a written artifact.
+
+IMPORTANT: when stating or discussing a Theory, follow `aai_coding.write_prose` closely. A Theory lives in minds, so its statement must be plain enough to hold there; slop cannot be anchored to.
+'''

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ coding_patterns = "aai_coding.coding_patterns"
 write_prose = "aai_coding.write_prose"
 harness_docs = "aai_coding.harness_docs"
 looker = "aai_coding.looker"
+theory = "aai_coding.theory"
 
 [project.scripts]
 aai-hook = "aai_coding.harness:main"


### PR DESCRIPTION
Inspired by write_prose.py I tried the same for Naur's Theory. I used it in a discussion and I was happy with the reply (but only after strict application of `write_prose.py`).

This is an example, discussing how to structure bash env files.

```
 Child processes inherit environment variables. They do not inherit aliases or functions. Everything in
  this setup follows from that.

  .bash_profile runs once, at login. Whatever it exports, every later process inherits, so it holds PATH
  and secrets. Since installed tools and credentials differ per machine, this is the machine-specific
  file. .bashrc runs for every interactive shell. Aliases and functions can't be inherited, so they must
  be redefined each time, and this is the file that does it, mostly by sourcing .aliases. .aliases holds
  only aliases and small functions. Nothing in it depends on being interactive or on a particular machine,
  so any shell can source it and it can be identical everywhere.

  The harness answer comes out directly. Its shells are non-interactive, so point BASH_ENV at .aliases and
  they get your vocabulary without any of the interactive machinery. Secrets are exports, so they sit in
  .bash_profile and never need re-reading. The two portable files are .aliases and .bashrc; .bash_profile
  stays local.

  Your old .shellrc mixed all three kinds of content behind a guard that returned in non-interactive
  shells. A non-interactive shell therefore got nothing from it, which is why s was missing here.
```