### PR TITLE
Add shortlink management PySkill

### DIFF
--- a/aai_coding/managing_shortlinks.py
+++ b/aai_coding/managing_shortlinks.py
@@ -1,0 +1,138 @@
+"""List, read, create, update, and delete Short.io links for one configured domain.
+
+Configure the process with `SHORT_IO_API_KEY` and `SHORT_IO_DOMAIN`. The optional `SHORT_IO_API_URL` overrides the API root for testing or a compatible service. Secrets belong in the process environment, never function arguments, prompts, source code, or output.
+
+Use `list_shortlinks` and `get_shortlink` for reads. `create_shortlink` creates one path. `update_shortlink` changes its destination, path, or title. Call `delete_shortlink(..., confirm=True)` only after the user explicitly approves that exact deletion.
+"""
+import json
+import os
+from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode, urlparse
+from urllib.request import Request, urlopen
+from pyskills.core import allow
+
+__all__ = [
+    'ShortlinksError',
+    'list_shortlinks',
+    'get_shortlink',
+    'create_shortlink',
+    'update_shortlink',
+    'delete_shortlink',
+]
+
+
+class ShortlinksError(RuntimeError):
+    "Short.io configuration or API failure"
+
+
+def normalize_shortlink_path(path):
+    "Return a validated Short.io path without surrounding slashes"
+    path = str(path).strip().strip('/')
+    if not path or path in {'.', '..'} or '/../' in f'/{path}/' or any(c in path for c in '?#') or any(c.isspace() for c in path):
+        raise ValueError(f'invalid shortlink path: {path!r}')
+    return path
+
+
+def validate_shortlink_url(url):
+    "Return a validated HTTP(S) destination URL"
+    url = str(url).strip()
+    parsed = urlparse(url)
+    if parsed.scheme not in {'http', 'https'} or not parsed.netloc:
+        raise ValueError('shortlink destination must be an http(s) URL')
+    return url
+
+
+class ShortlinksClient:
+    "Short.io client configured from the process environment"
+
+    def __init__(self):
+        self.api_key = os.environ.get('SHORT_IO_API_KEY')
+        self.domain = os.environ.get('SHORT_IO_DOMAIN')
+        self.api_url = os.environ.get('SHORT_IO_API_URL', 'https://api.short.io').rstrip('/')
+        if not self.api_key: raise ShortlinksError('SHORT_IO_API_KEY is not configured')
+        if not self.domain: raise ShortlinksError('SHORT_IO_DOMAIN is not configured')
+
+    def request(self, method, path, query=None, body=None):
+        "Send one authenticated API request and return decoded JSON"
+        url = f'{self.api_url}{path}'
+        if query: url = f'{url}?{urlencode(query)}'
+        data = json.dumps(body).encode() if body is not None else None
+        headers = {'Accept': 'application/json', 'Authorization': self.api_key}
+        if data is not None: headers['Content-Type'] = 'application/json'
+        try:
+            with urlopen(Request(url, data=data, headers=headers, method=method), timeout=30) as response:
+                raw = response.read()
+                return json.loads(raw) if raw else None
+        except HTTPError as e:
+            raw = e.read()
+            try:
+                error = json.loads(raw)
+                message = error.get('message') or error.get('error') or str(error)
+            except (json.JSONDecodeError, AttributeError):
+                message = raw.decode(errors='replace') or e.reason
+            raise ShortlinksError(f'Short.io API returned {e.code}: {message}') from None
+        except URLError as e:
+            raise ShortlinksError(f'could not reach Short.io: {e.reason}') from None
+
+    def domain_id(self):
+        "Return the configured domain's Short.io ID"
+        result = self.request('GET', '/api/domains', {'limit': 300, 'pattern': self.domain})
+        domains = result if isinstance(result, list) else result.get('domains', result.get('data', []))
+        for domain in domains:
+            if domain.get('hostname') == self.domain: return domain['id']
+        raise ShortlinksError(f'Short.io domain is unavailable: {self.domain}')
+
+
+def list_shortlinks():
+    "List every shortlink in `SHORT_IO_DOMAIN`"
+    client = ShortlinksClient()
+    domain_id = client.domain_id()
+    links, token = [], None
+    while True:
+        query = {'domain_id': domain_id, 'limit': 150}
+        if token: query['pageToken'] = token
+        result = client.request('GET', '/api/links', query)
+        links.extend(result.get('links', []))
+        token = result.get('nextPageToken')
+        if not token: return links
+
+
+def get_shortlink(path):
+    "Get one shortlink by path"
+    client = ShortlinksClient()
+    return client.request('GET', '/links/expand', {'domain': client.domain, 'path': normalize_shortlink_path(path)})
+
+
+def create_shortlink(path, url, title=None):
+    "Create `path` pointing to `url`"
+    client = ShortlinksClient()
+    body = {
+        'domain': client.domain,
+        'path': normalize_shortlink_path(path),
+        'originalURL': validate_shortlink_url(url),
+    }
+    if title is not None: body['title'] = str(title)
+    return client.request('POST', '/links', body=body)
+
+
+def update_shortlink(path, *, url=None, new_path=None, title=None):
+    "Update the destination, path, or title of one shortlink"
+    if url is None and new_path is None and title is None: raise ValueError('provide at least one change')
+    client = ShortlinksClient()
+    link = client.request('GET', '/links/expand', {'domain': client.domain, 'path': normalize_shortlink_path(path)})
+    body = {}
+    if url is not None: body['originalURL'] = validate_shortlink_url(url)
+    if new_path is not None: body['path'] = normalize_shortlink_path(new_path)
+    if title is not None: body['title'] = str(title)
+    return client.request('POST', f"/links/{link['idString']}", body=body)
+
+
+def delete_shortlink(path, *, confirm=False):
+    "Delete one shortlink after explicit confirmation"
+    if not confirm: raise ValueError('shortlink deletion requires explicit confirmation')
+    client = ShortlinksClient()
+    link = client.request('GET', '/links/expand', {'domain': client.domain, 'path': normalize_shortlink_path(path)})
+    return client.request('DELETE', f"/links/{link['idString']}")
+
+
+allow(list_shortlinks, get_shortlink, create_shortlink, update_shortlink, delete_shortlink)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
   "Programming Language :: Python :: 3 :: Only",
 ]
 
-dependencies = ["llmdojo>=0.0.1"]
+dependencies = ["llmdojo>=0.0.1", "pyskills"]
 
 [project.entry-points.pyskills]
 coding_patterns = "aai_coding.coding_patterns"
@@ -25,6 +25,7 @@ write_summary = "aai_coding.write_summary"
 harness_docs = "aai_coding.harness_docs"
 looker = "aai_coding.looker"
 theory = "aai_coding.theory"
+"managing-shortlinks" = "aai_coding.managing_shortlinks"
 
 [project.scripts]
 aai-hook = "aai_coding.harness:main"

--- a/tests/test_managing_shortlinks.py
+++ b/tests/test_managing_shortlinks.py
@@ -1,0 +1,98 @@
+import json
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from threading import Thread
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+
+from aai_coding.managing_shortlinks import (
+    ShortlinksError,
+    create_shortlink,
+    delete_shortlink,
+    get_shortlink,
+    list_shortlinks,
+    update_shortlink,
+)
+
+
+@pytest.fixture
+def shortio(monkeypatch):
+    requests = []
+
+    class Handler(BaseHTTPRequestHandler):
+        def log_message(self, format, *args): pass
+
+        def reply(self, body, status=200):
+            data = json.dumps(body).encode()
+            self.send_response(status)
+            self.send_header('Content-Type', 'application/json')
+            self.send_header('Content-Length', str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
+        def record(self):
+            n = int(self.headers.get('Content-Length', 0))
+            body = json.loads(self.rfile.read(n)) if n else None
+            requests.append((self.command, self.path, body, self.headers.get('Authorization')))
+            return body
+
+        def do_GET(self):
+            self.record()
+            u = urlparse(self.path)
+            q = parse_qs(u.query)
+            if u.path == '/api/domains': return self.reply([
+                {'id': 9, 'hostname': 'other.example'},
+                {'id': 42, 'hostname': 'link.answer.ai'},
+            ])
+            if u.path == '/api/links':
+                assert q['domain_id'] == ['42']
+                if q.get('pageToken') == ['next']:
+                    return self.reply({'links': [{'path': 'wiki'}], 'nextPageToken': None})
+                return self.reply({'links': [{'path': 'discord'}], 'nextPageToken': 'next'})
+            if u.path == '/links/expand':
+                assert q['domain'] == ['link.answer.ai']
+                return self.reply({'path': q['path'][0], 'idString': 'lnk_123', 'originalURL': 'https://old.example'})
+            return self.reply({'error': 'missing'}, 404)
+
+        def do_POST(self):
+            body = self.record()
+            if self.path == '/links': return self.reply({'idString': 'lnk_new', **body})
+            if self.path == '/links/lnk_123': return self.reply({'idString': 'lnk_123', **body})
+            return self.reply({'error': 'missing'}, 404)
+
+        def do_DELETE(self):
+            self.record()
+            if self.path == '/links/lnk_123': return self.reply({'success': True})
+            return self.reply({'error': 'missing'}, 404)
+
+    server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    monkeypatch.setenv('SHORT_IO_API_KEY', 'test-key')
+    monkeypatch.setenv('SHORT_IO_DOMAIN', 'link.answer.ai')
+    monkeypatch.setenv('SHORT_IO_API_URL', f'http://127.0.0.1:{server.server_port}')
+    yield requests
+    server.shutdown()
+    thread.join()
+
+
+def test_shortlinks_crud(shortio):
+    assert [x['path'] for x in list_shortlinks()] == ['discord', 'wiki']
+    assert get_shortlink('dm/jeremy')['idString'] == 'lnk_123'
+    created = create_shortlink('dm/jeremy', 'https://discord.com/users/123', title='Jeremy')
+    assert created['path'] == 'dm/jeremy'
+    updated = update_shortlink('dm/jeremy', url='https://discord.com/users/456', new_path='dm/j')
+    assert updated['originalURL'] == 'https://discord.com/users/456'
+    assert updated['path'] == 'dm/j'
+    assert delete_shortlink('dm/jeremy', confirm=True) == {'success': True}
+    assert {r[3] for r in shortio} == {'test-key'}
+    assert sum(path.startswith('/api/domains') for _, path, _, _ in shortio) == 1
+
+
+def test_shortlinks_safety(shortio, monkeypatch):
+    with pytest.raises(ValueError, match='confirmation'): delete_shortlink('wiki')
+    with pytest.raises(ValueError, match='http'): create_shortlink('wiki', 'javascript:alert(1)')
+    with pytest.raises(ValueError, match='path'): create_shortlink('../wiki', 'https://example.com')
+    with pytest.raises(ValueError, match='change'): update_shortlink('wiki')
+    monkeypatch.delenv('SHORT_IO_API_KEY')
+    with pytest.raises(ShortlinksError, match='SHORT_IO_API_KEY'): list_shortlinks()


### PR DESCRIPTION
> **This PR was drafted by AI.**

Short.io links are currently managed through its dashboard. This adds a PySkill for safe, repeatable management from coding sessions and services such as Dizcord Buddy.

- Configure the domain and key with SHORT_IO_DOMAIN and SHORT_IO_API_KEY.
- List, read, create, update, and delete links through explicit shortlink functions.
- Validate paths and destinations, and require confirmation for deletion.
- Register network calls for the PySkill sandbox.

Tests use a local HTTP server and cover CRUD, pagination, authentication, and safety checks. A read-only live check listed the six current link.answer.ai links from Short.io.
