### PR TITLE
The bash guard's 2>&1 message no longer suggests a redirect

### DIFF
--- a/aai_coding/harness.py
+++ b/aai_coding/harness.py
@@ -7,9 +7,8 @@ __all__ = ['main']
 
 NO_TRUNCATE = ('Output pipe truncates below 20 lines. Drop the pipe or keep >=20: truncation is decided '
     'before the output exists, so keep enough to diagnose surprises.')
-NO_STDERR_MERGE = ('Do not merge stderr into stdout with 2>&1. Remove redirection entirely where possible - '
-    'the harness automatically pushes large outputs to external files when needed; use this form where '
-    'strictly needed: `>meta/stdout.txt 2>meta/stderr.txt`, reading the files with clikernel.')
+NO_STDERR_MERGE = ('Do not merge stderr into stdout with 2>&1. Run the command bare: the harness pushes large '
+    'output to a file by itself, and stderr kept separate makes a crash unmissable.')
 _TRUNC = re.compile(r'\|\s*(tail|head)\s+(-n\s*)?-?([1-9]|1[0-9])\b')
 _MERGE = re.compile(r'2>\s*&\s*1')
 


### PR DESCRIPTION
The block message told the model to run bare but then offered a file-redirect form, which is what it reached for next. It now says to run the command bare and why.