### PR TITLE
Add starter workspace setup and use aidialog for notebook workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 The Answer.AI coding harness: the shared configuration, skills, and tooling that make a Claude Code or codex session work the way our team works. If you are an LLM reading this, you are probably either setting the harness up (follow `SETUP.md`, but read this file first) or working inside it and wanting to understand why it is shaped this way, so you can give your user informed advice.
 
+## Getting started
+
+You do not need an Answer.AI account or our existing workspace. [SETUP.md](SETUP.md) starts with a workspace in a directory you choose, managed by [fastws](https://github.com/AnswerDotAI/fastws), then walks through configuring the harness. The workspace holds separate Git checkouts sharing one uv environment; its Python projects are installed editably, so changes in a checkout are available without reinstalling it.
+
+The copyable [repos.txt](repos.txt) supplies a small starter workspace for the setup below, not our full collection of projects. It includes aai-coding, fastws, the kernel startup and editing tools, and the tools used by the Claude hooks. Other Python dependencies are installed as packages; add their repos when you want editable source checkouts too.
+
 ## The system in one paragraph
 
-The Claude Code setup and one codex setup are kernel-centric: native file tools are denied, and file reading, editing, searching, and Python execution go through one persistent IPython kernel (clikernel) loaded with curated tooling discovered via `pyskills`. Codex can instead use a hybrid setup: normal `apply_patch` and Bash for files and shell work, with a quiet clikernel reserved for Python-specific work. The kernel-centric setup uses two host-level bootstrap skills, `persistent-python` and `pyskills`; the hybrid setup uses `clikernel-workflow` to define the boundary and `notebook-dialog-editing` for safe kernel-free notebook and aidialog work. Everything else that would conventionally be a host skill is a pyskill in this package: skill text lives in module docstrings, read with `doc()`, listed by `list_pyskills()`, and versioned, released, and installed like any other Python code.
+The Claude Code setup and one codex setup are kernel-centric: native file tools are denied, and file reading, editing, searching, and Python execution go through one persistent IPython kernel (clikernel) loaded with curated tooling discovered via `pyskills`. Codex can instead use a hybrid setup: normal `apply_patch` and Bash for files and shell work, with a quiet clikernel reserved for Python-specific work. The kernel-centric setup uses two host-level bootstrap skills, `persistent-python` and `pyskills`; the hybrid setup uses `clikernel-workflow` to define the boundary and `notebook-dialog-editing` as the CLI adapter for the required `aidialog.dlgskill` entry point. That adapter overrides pyskill tool preferences for local files: use native tools within allowed editing locations. Everything else that would conventionally be a host skill is a pyskill in this package: skill text lives in module docstrings, read with `doc()`, listed by `list_pyskills()`, and versioned, released, and installed like any other Python code.
 
 ## What is in here
 
@@ -13,6 +19,7 @@ The Claude Code setup and one codex setup are kernel-centric: native file tools 
 - `plugins/safecmd/` - a Claude Code plugin that auto-approves allowlisted Bash commands via the `safecmd` package, so the deny-heavy permission setup stays livable.
 - `prompts/` - shared prompt text. `core.md` holds harness-neutral behavioral rules: codex reads it natively via a `~/.codex/AGENTS.md` symlink, and Claude Code can append it. `sysp.md` is a full replacement for Claude Code's default system prompt, tuned against the default's consultant and action biases; install it as a `~/.claude/sysp` symlink and launch with `claude --system-prompt-file ~/.claude/sysp --append-system-prompt-file <this repo>/prompts/core.md` (replacement drops the default prompt's prose but tool schemas survive; the dynamic environment block and scratchpad path are the known losses).
 - `SETUP.md` - the setup runbook, written as a prompt for an LLM session rather than an installer script.
+- `repos.txt` - a starter repo list to copy into your workspace root, then extend with your own projects.
 
 ## Design decisions, and why
 
@@ -24,6 +31,8 @@ The Claude Code setup and one codex setup are kernel-centric: native file tools 
 
 ## Using and changing it
 
-Day to day there is nothing to operate. Kernel-centric sessions bootstrap through `persistent-python`; hybrid codex sessions use `clikernel-workflow` for Python, `notebook-dialog-editing` for notebooks and aidialog dialogs, and the native tools otherwise. Both discover Python tooling through the pyskills catalog and read it with `doc()` or `pyskills-doc`. To change a skill, edit its source in this checkout and let the team pick it up by pulling; releases go through the standard fastship flow (`ship-release`), with the version in `aai_coding/__init__.py` bumped after each release.
+Activate the workspace's `.venv`, then work in a project checkout. Use `ws-status` to inspect local changes, `ws-sync` to pull and install updates, and `ws-add owner/repo` to add a project. See [the workspace workflow](SETUP.md#using-the-workspace) for details, including what syncing changes.
+
+The harness itself needs no manual startup each day. Kernel-centric sessions bootstrap through `persistent-python`; hybrid codex sessions use `clikernel-workflow` for Python, `notebook-dialog-editing` for notebooks and aidialog dialogs, and the native tools otherwise. Both discover Python tooling through the pyskills catalog and read it with `doc()` or `pyskills-doc`. To change a skill, edit its source in this checkout and let others pick it up by pulling; releases go through the standard fastship flow (`ship-release`), with the version in `aai_coding/__init__.py` bumped after each release.
 
 Tests cover substantive logic where hidden errors are realistic: event ordering, accumulated state, duplicate suppression, and PDF rendering. Do not add tests for prompt wording, straightforward dispatch, or trivial configuration branches. Run the retained tests with `pytest`.

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,8 +1,72 @@
 # Setting up the Answer.AI harness
 
-This file is a runbook for an LLM session, not a script. If you are a person: open Claude Code or codex, `cd` anywhere in the aai-ws workspace, and say "follow aai-coding/SETUP.md". If you are the session: first read `README.md` in this repo in full, since the steps below change your user's configuration and the README's design context is what lets you merge, recommend, and answer questions in an informed way. Then work through the steps in order. Each step states an outcome to reach, a check, and what to settle with the user first. Make no change beyond the stated outcomes without asking. Where the user's existing configuration overlaps, merge and never replace: show them each conflict and agree a resolution.
+This file is a runbook for an LLM session, not a script. It sets up our way of working without requiring an Answer.AI account or a copy of our workspace. If you are a person: start with step 0 to create a workspace and get this repo, then open Claude Code or codex in the workspace and say "follow aai-coding/SETUP.md". If you already have the checkout, you can ask a session to follow this file from there, including step 0.
 
-Assumptions: macOS, the aai-ws uv workspace cloned and synced (this repo is a member, so its `aai-hook` CLI and pyskills are already installed), and at least one harness (Claude Code or codex) installed and signed in. Ask which harnesses to set up before starting, and use absolute paths for this repo and the workspace venv throughout.
+If you are the session: first read `README.md` in this repo in full, since the steps below change your user's configuration and the README's design context is what lets you merge, recommend, and answer questions in an informed way. Then work through the steps in order, checking existing setup before making changes. Make no change beyond the stated outcomes without asking. Where the user's existing configuration overlaps, merge and never replace: show them each conflict and agree a resolution.
+
+This runbook targets macOS; the workspace commands use Bash/Zsh syntax. Do not apply the macOS sound hooks on other systems. Before harness configuration, at least one harness (Claude Code or codex) must be installed and signed in. Ask which harnesses to set up and where the workspace should live. No particular workspace name is required. Below, `<workspace>` means its absolute path, `<venv>` means `<workspace>/.venv`, and `<this repo>` means `<workspace>/aai-coding`. Resolve those placeholders before writing configuration; neither `~` nor shell variables are a substitute for an absolute path in config files.
+
+## 0. Create a fastws workspace
+
+Outcome: a workspace with the starter repos cloned, its shared uv environment activated, and the harness packages installed. If the user already has a fastws workspace, reuse it: merge missing entries from this repo's `repos.txt` into the workspace's list instead of copying over it, keep its Python version unless a dependency requires a change, and skip creation commands for things that already exist. Do not duplicate or move an existing aai-coding checkout without agreeing its location first.
+
+### Prerequisites
+
+- Git and [uv](https://docs.astral.sh/uv/getting-started/installation/) installed. Check `git --version` and `uv --version`.
+- GitHub SSH access: fastws clones `owner/repo` entries using `git@github.com:owner/repo.git`. Check `git ls-remote git@github.com:AnswerDotAI/aai-coding.git HEAD`; fix authentication before cloning. The starter repos are public and require no Answer.AI organization membership.
+- Rust (`rustc --version`, `cargo --version`) and native build tools (Xcode Command Line Tools on macOS). The starter builds exhash and rgapi from source. Ask before installing missing toolchains.
+- Network access for cloning and installing packages.
+
+### Create, clone, and sync
+
+For a new workspace, the following example uses `~/coding-ws`; choose a different directory as needed. Run the commands in the same shell. Clone aai-coding first to obtain the starter list, then let fastws clone the remaining repos:
+
+```bash
+mkdir -p ~/coding-ws
+cd ~/coding-ws
+git clone git@github.com:AnswerDotAI/aai-coding.git
+cp aai-coding/repos.txt repos.txt
+uv venv --python 3.13
+source .venv/bin/activate
+uv pip install fastws-cli
+ws-clone
+ws-sync
+```
+
+`ws-clone` skips existing directories: inspect its output and check that every listed checkout exists, rather than treating an exit code as proof. `ws-sync` creates the workspace metadata and installs its Python projects editably in the shared environment. It also pulls updates; it is not just an install command. No clone of Answer.AI's workspace or hand-written workspace `pyproject.toml` is needed. See [fastws's documentation](https://github.com/AnswerDotAI/fastws) for the full command reference.
+
+The starter list is deliberately small:
+
+| Repo | Why it is included |
+|---|---|
+| `AnswerDotAI/fastws` | Workspace commands, kept up to date alongside the harness. The distribution name is `fastws-cli`. |
+| `AnswerDotAI/aai-coding` | Skills, prompts, and plugins linked from this checkout, plus the `aai-hook` CLI. |
+| `AnswerDotAI/llmdojo` | Kernel startup files linked in step 2, and the kernel-centric bootstrap. |
+| `AnswerDotAI/ipykernel-helper` | Startup helpers, plus the IPython and ipykernel dependencies needed to run Python kernels. |
+| `AnswerDotAI/exhash` | Hash-verified editing tools imported by startup and used by the notebook CLI workflow. |
+| `AnswerDotAI/rgapi` | Search tools imported by startup, including the notebook search CLI. |
+| `AnswerDotAI/safecmd` | Command approval tool used by the Claude setup; not an aai-coding package dependency. |
+| `AnswerDotAI/slopometer` | Prose scoring tool used by the Claude hooks; not an aai-coding package dependency. |
+
+This is a starter for the documented setup, not a strict minimum for each harness mode. Dependencies such as clikernel, pyskills, and aidialog are installed through package dependencies rather than all needing source checkouts. The workspace's `repos.txt` is your own copy: add your projects to it through fastws, and do not symlink it back to this repo's starter list.
+
+### Check the environment
+
+From the activated shell:
+
+```bash
+command -v python ws-sync aai-hook clikernel-mcp pyskills-doc safecmd slopometer
+command -v aidialog-summary exhash-cell lnhashview-cell exhash-open rgapi-nbrg
+uv pip check
+pyskills-doc aai_coding.coding_patterns
+python llmdojo/claude/startup.py
+```
+
+Run these from the workspace root. The commands should resolve inside `<venv>/bin`, package dependencies should be consistent, and the skill documentation should render. Running the startup script should import its tooling and print the bootstrap instructions; it does not run the dojo or replace the live kernel checks in steps 7–8. Resolve missing dependencies or commands before installing hooks: another environment on PATH can otherwise hide an incomplete setup.
+
+In each new shell, activate the workspace environment before launching the harness. Ask before adding `source <venv>/bin/activate` to the user's shell startup file; global auto-activation is convenient but not required. GUI-launched harnesses may not inherit the shell's PATH, so use absolute executable paths in configuration and ensure hook subprocesses can find the workspace tools too.
+
+## Choose a harness mode
 
 Codex has two supported modes. This choice applies only to codex; Claude Code remains kernel-centric. Settle which codex mode the user wants before changing its configuration:
 
@@ -13,11 +77,11 @@ Codex has two supported modes. This choice applies only to codex; Claude Code re
 
 Outcome: the clikernel MCP server is registered. Claude Code: a user-scope server named `clikernel` running `<venv>/bin/clikernel-mcp`. Kernel-centric codex: a `[mcp_servers.clikernel]` block in `~/.codex/config.toml` with `command` set to that binary, `startup_timeout_sec = 30`, `tool_timeout_sec = 3600`, and `approval_mode = "approve"` for its `execute`, `connect`, `restart`, and `interrupt` tools.
 
-Hybrid codex: use the following exact working configuration, changing the `command` path if the workspace is elsewhere:
+Hybrid codex: use the following configuration, replacing `<venv>` with the absolute workspace environment path:
 
 ```toml
 [mcp_servers.clikernel]
-command = "/Users/jhoward/aai-ws/.venv/bin/clikernel-mcp"
+command = "<venv>/bin/clikernel-mcp"
 args = ["--quiet"]
 env_vars = ["GITHUB_TOKEN"]
 omit_tools_from = ["deferred"]
@@ -79,7 +143,7 @@ Check: the file still parses as JSON after editing.
 
 Outcome: symlinks from `~/.claude/skills/persistent-python` and `~/.claude/skills/pyskills` to `<this repo>/skills/<name>`. Kernel-centric codex gets the same two skill symlinks. Hybrid codex instead gets `~/.codex/skills/clikernel` pointing to `<this repo>/skills/clikernel` and `~/.codex/skills/notebook-dialog-editing` pointing to `<this repo>/skills/notebook-dialog-editing`; the latter teaches Codex to inspect and edit notebooks and aidialog dialogs safely through the shell CLIs without using a kernel. Remove the other mode's codex skill symlinks when switching, since they intentionally prescribe conflicting tool-use policies. Also link `~/.claude/skills/safecmd` to `<this repo>/plugins/safecmd` and `~/.codex/AGENTS.md` to `<this repo>/prompts/core.md`.
 
-safecmd auto-approves allowlisted Bash commands. The `safecmd` package is a workspace member, so it is already installed; its allowlist lives at `~/.config/safecmd/config.ini` and the defaults are fine to start.
+safecmd auto-approves allowlisted Bash commands. The starter workspace installs the `safecmd` package; its allowlist lives at `~/.config/safecmd/config.ini` and the defaults are fine to start. The starter also installs `slopometer` for the prose-scoring hook. Its first score downloads a spaCy language model into `~/.cache/slopometer`; tell the user to expect that download. Without the executable, the prose hook silently skips scoring, so check it explicitly rather than assuming the hook registration proves it works.
 
 Optional, Claude Code: the user might like `<this repo>/prompts/core.md` appended to the system prompt; a shell alias adding `--append-system-prompt-file <this repo>/prompts/core.md` to `claude` does it. The stronger option is the team's full behavioral prompt: symlink `~/.claude/sysp` to `<this repo>/prompts/sysp.md` and alias `claude` to `claude --system-prompt-file ~/.claude/sysp --append-system-prompt-file <this repo>/prompts/core.md`, which replaces Claude Code's default prompt entirely. Explain the trade to the user before wiring it: the default's tool schemas survive replacement, but its dynamic environment block and scratchpad path do not, and the behavioral text takes over from the default's guidance.
 
@@ -100,3 +164,13 @@ Both harnesses read configuration at startup: ask the user to restart each, acce
 In a fresh Claude Code or kernel-centric codex session in any workspace Python project: the bootstrap notice fires; invoking `persistent-python` then running `dojo_start()` completes a clean round; `list_pyskills()` shows the `aai_coding.*` rows; `doc(aai_coding.coding_patterns)` renders.
 
 In a fresh hybrid codex session: `clikernel-workflow` and `notebook-dialog-editing` appear in the available skills; ordinary local text edits use `apply_patch`; notebook and aidialog work can use the shell CLIs without starting a kernel; shell work uses Bash; and clikernel retains Python state across two execution calls. Inside clikernel, `list_pyskills()` shows the `aai_coding.*` rows and `doc(aai_coding.coding_patterns)` renders. When a check fails, fix that step's wiring before moving on, and tell the user what was wrong.
+
+## Using the workspace
+
+Activate `<venv>/bin/activate` in your shell, then `cd` into a project checkout to work or launch the harness. Each checkout remains a separate Git repo, but the Python projects share one environment. Run project commands and tests there as usual; importing another workspace package uses its editable checkout.
+
+- **Inspect:** `ws-status` shows uncommitted changes and unpushed commits across repos. Review these before updating; preserve local work and resolve any pull conflicts normally.
+- **Update:** `ws-sync` pulls repos, refreshes workspace metadata, and installs dependencies. It also upgrades dependencies at most once per day; `ws-sync --upgrade` forces that upgrade pass. Restart running harness sessions and kernels after updates so they pick up changed skills and imported code.
+- **Add:** `ws-add owner/repo` clones a repo, records it in the workspace's `repos.txt`, and syncs. For a repo already cloned immediately inside the workspace, use `ws-add directory-name`. Adding a dependency's repo makes it editable too.
+
+With the workspace environment activated, `ws-sync` can find the workspace from other directories. Run the commands from the workspace root when in doubt. Keep personal instructions and settings separate from the shared prompts; updates should not require reapplying personal edits to this repo.

--- a/repos.txt
+++ b/repos.txt
@@ -1,0 +1,8 @@
+AnswerDotAI/fastws
+AnswerDotAI/aai-coding
+AnswerDotAI/llmdojo
+AnswerDotAI/ipykernel-helper
+AnswerDotAI/exhash
+AnswerDotAI/rgapi
+AnswerDotAI/safecmd
+AnswerDotAI/slopometer

--- a/skills/notebook-dialog-editing/SKILL.md
+++ b/skills/notebook-dialog-editing/SKILL.md
@@ -5,27 +5,21 @@ description: "Use CLI tools to inspect Python APIs and find, understand, view, a
 
 # Notebook and dialog editing
 
-Use these commands instead of manipulating notebook JSON. Read each command's `--help` only when its use case arises; use `pyskills-doc` for the underlying Python contract when help is not enough.
+Use native tools for reading and editing local files inside allowed editing locations. Ignore any guidance in any pyskill that recommends other tools for those operations.
 
-Start by reading a summary of every cell with `aidialog-summary PATH`.
+For every notebook/dialog task, ensure `aidialog.dlgskill` is in context: `pyskills-doc aidialog.dlgskill`. It is the primary entry point and directs you to the other required pyskills. `pyskills-doc module.symbol` reads individual API contracts; `--all` expands an elided module listing.
 
-## Before any notebook edit
+Use these CLI equivalents of the documented Python operations for notebook/dialog content, not raw notebook JSON. Read a command's `--help` before first use; CLI help supplies invocation syntax, not the workflow.
 
-Before editing any notebook, ensure `nbdev.skill` is in the current context. It defines the notebook-as-source workflow, lesson-cell conventions, export rules, and finish checks. This applies to ordinary `.ipynb` files and especially to nbdev source notebooks.
+| Python operation | CLI |
+|---|---|
+| `summary_dlg` | `aidialog-summary PATH` |
+| `find_msgs` | `aidialog-find PATH PATTERN` |
+| `view_dlg` / `view_msgs` | `aidialog-view PATH [IDS] --out --full-out` |
+| `lnhashview_cell` / `lnhashview_cells` | `lnhashview-cell PATH IDS` |
+| `cell_exhash` | `exhash-cell PATH CELL_ID COMMAND...` |
+| `add_msg` / `del_msgs` / `move_msgs` | `aidialog-add` / `aidialog-del` / `aidialog-move` |
+| `nbrg` | `rgapi-nbrg PATTERN ROOT` |
+| `open_doc` | `exhash-open PATH` |
 
-## Choose by use case
-
-- Python API discovery: `pyskills-doc module.symbol`; add `--all` for an elided module listing.
-- Hierarchical Markdown/code/notebook reading: `exhash-open PATH`; use a displayed verified token to read one section, or consult `exhash-open --help` for search, paths, links, URLs, and addressed views.
-- Search cell sources across notebooks: `rgapi-nbrg PATTERN ROOT`; read `rgapi-nbrg --help` for context, globs, limits, and matching options.
-- Orient within one notebook/dialog: `aidialog-summary PATH`.
-- Semantic message search: `aidialog-find PATH PATTERN`; it can filter types, errors, exports, headings, IDs, and context. Read `aidialog-find --help` for details.
-- Read the complete narrative and outputs: `aidialog-view PATH --out --full-out`; pass a message ID for a targeted view. Multiple IDs are comma-separated.
-- Get edit-ready cell lines: `lnhashview-cell PATH CELL_ID`; pass comma-separated IDs to view several cells together. Use its fresh `line|hash|` addresses with `exhash-cell`.
-- Edit cell source safely: `exhash-cell PATH CELL_ID COMMAND...`; each CLI command is one compact argument with the verified address immediately followed by its operation, such as `'3|beef|s/old/new/'` or `'3|beef|c'`. One multiline `a`/`i`/`c` command may read its literal text from stdin through EOF. Read `exhash-cell --help` and `pyskills-doc exhash.skill` for the command language. Re-view after every edit call before constructing another.
-- Stored outputs are generated artifacts and may be stale while source is being edited. Never stop, clear outputs manually, or manipulate notebook JSON because an edited cell retains old output. At PR time, regenerate outputs with `nbdev-test --save` when the project needs saved outputs updated.
-- Add, delete, or move messages: `aidialog-add`, `aidialog-del`, and `aidialog-move`. IDs are comma-separated; use `--dry-run` when previewing placement or removal. Read the command's help before first use.
-
-For dialog semantics beyond CLI help, run `pyskills-doc aidialog.dlgskill`. For notebook search semantics, run `pyskills-doc rgapi.skill`.
-
-If a structural operation is missing, extend the owning CLI rather than splicing raw `.ipynb` JSON.
+CLI ID lists are comma-separated. Exhash commands are compact arguments, e.g. `'3|beef|s/old/new/'`; one multiline `a`/`i`/`c` command can take literal stdin through EOF. For a missing structural operation, extend the owning CLI.


### PR DESCRIPTION
The setup guide starts from a new fastws workspace with a starter repos.txt. The notebook CLI adapter requires aidialog.dlgskill and retains native local-file tools. See Getting started and Notebook and dialog editing.