### PR TITLE
Require Python 3.11, matching the llmdojo floor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "aai-coding"
 dynamic = ["version"]
 description = "Pyskills for Answer.AI coding sessions"
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 license = { text = "Apache-2.0" }
 authors = [{ name = "aai-coding contributors" }]
 classifiers = [


### PR DESCRIPTION
One character. `requires-python = ">=3.10"` while the sole runtime dependency, `llmdojo>=0.0.3`, requires `>=3.11`.

uv resolves across the whole declared range, so it fails on the 3.10 leg before it ever reaches the interpreter actually in use. On a clean checkout with Python 3.13:

```
Because the requested Python version (>=3.10) does not satisfy Python>=3.11 and
llmdojo>=0.0.3 depends on Python>=3.11, we can conclude that llmdojo>=0.0.3 cannot be used.
...
hint: The `requires-python` value (>=3.10) includes Python versions that are not supported
by your dependencies (e.g., llmdojo>=0.0.3 only supports >=3.11).
```

`uv run pytest` is therefore unusable on a fresh clone. With the floor corrected the environment builds and `tests/test_harness.py` passes:

```
....                                                                     [100%]
4 passed in 0.12s
```

## One thing this does not fix

`tests/test_looker.py` still fails to import, for an unrelated reason:

```
aai_coding/looker.py:5: in <module>
    import Quartz
E   ModuleNotFoundError: No module named 'Quartz'
```

`Quartz` (pyobjc) is not among the declared dependencies. Left alone here since it is a separate question, and macOS-only, so it may want an extra rather than a hard dependency.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
